### PR TITLE
Implement better dsl for releasePhase/releaseNotes in KTS

### DIFF
--- a/README.md
+++ b/README.md
@@ -273,28 +273,28 @@ huaweiPublish {
          * Default value: `null` // (means the build will be published immediately to 100% users)
          * CLI: (see ReleasePhase param desc.)
          */
-          releasePhase = ru.cian.huawei.publish.ReleasePhaseExtension(
+          releasePhase {
               /**
                * Start release time after review in UTC format. The format is 'yyyy-MM-dd'T'HH:mm:ssZZ'.
                * Type: String (Required)
                * CLI: `--releasePhaseStartTime`
                */
-                startTime = "2025-01-18T21:00:00+0300",
+              startTime = "2025-01-18T21:00:00+0300"
 
               /**
                * End release time after review in UTC format. The format is 'yyyy-MM-dd'T'HH:mm:ssZZ'.
                * Type: String (Required)
                * CLI: `--releasePhaseEndTime`
                */
-                endTime = "2025-01-21T06:00:00+0300",
+              endTime = "2025-01-21T06:00:00+0300"
 
               /**
                * Percentage of target users of release by phase. The integer or decimal value from 0 to 100.
                * Type: String (Required)
                * CLI: `--releasePhasePercent`
                */
-                percent = 5.0 // (equals to 5%)
-          )
+              percent = 5.0 // (equals to 5%)
+          }
 
         /**
          * Description: Release Notes settings. For more info see documentation below.
@@ -302,7 +302,7 @@ huaweiPublish {
          * Default value: `null`
          * CLI: (see ReleaseNotes param desc.)
          */
-          releaseNotes = ru.cian.huawei.publish.ReleaseNotesExtension(
+          releaseNotes {
 
               /**
                * Release Notes by languages. For more info see documentation below.
@@ -336,7 +336,7 @@ huaweiPublish {
                                 lang = "ru-RU",
                                 filePath = "$projectDir/release-notes-ru.txt"
                       ),
-                ),
+                )
 
               /**
                * :warning: !!!EXPERIMENTAL!!!
@@ -346,7 +346,7 @@ huaweiPublish {
                * CLI: (See `--removeHtmlTags` desc.)
                */
                 removeHtmlTags = false
-          )
+          }
 
         /**
          * Description: Path to json file with params to update app basic info [Huawei Publish API](https://developer.huawei.com/consumer/en/doc/development/AppGallery-connect-References/agcapi-app-info-update-0000001111685198))

--- a/plugin/src/main/kotlin/ru/cian/huawei/publish/HuaweiPublishExtension.kt
+++ b/plugin/src/main/kotlin/ru/cian/huawei/publish/HuaweiPublishExtension.kt
@@ -1,6 +1,7 @@
 package ru.cian.huawei.publish
 
 import groovy.lang.Closure
+import org.gradle.api.Action
 import org.gradle.api.Project
 
 private const val DEFAULT_PUBLISH_SOCKET_TIMEOUT_IN_SECONDS = 60L
@@ -40,8 +41,8 @@ class HuaweiPublishExtensionConfig(
     var buildFormat: BuildFormat = BuildFormat.APK
     var buildFile: String? = null
     var releaseTime: String? = null
-    var releasePhase: ReleasePhaseExtension? = null
-    var releaseNotes: ReleaseNotesExtension? = null
+    var releasePhase: ReleasePhaseExtension = ReleasePhaseExtension()
+    var releaseNotes: ReleaseNotesExtension = ReleaseNotesExtension()
     var appBasicInfo: String? = null
 
     init {
@@ -51,15 +52,25 @@ class HuaweiPublishExtensionConfig(
     }
 
     fun releasePhase(closure: Closure<ReleasePhaseExtension>): ReleasePhaseExtension {
-        releasePhase = ReleasePhaseExtension()
-        project.configure(releasePhase!!, closure)
-        return releasePhase!!
+        project.configure(releasePhase, closure)
+        return releasePhase
+    }
+
+    fun releasePhase(action: Action<ReleasePhaseExtension>): ReleasePhaseExtension {
+        action.execute(releasePhase)
+        return releasePhase
     }
 
     fun releaseNotes(closure: Closure<ReleaseNotesExtension>): ReleaseNotesExtension {
         releaseNotes = ReleaseNotesExtension()
-        project.configure(releaseNotes!!, closure)
-        return releaseNotes!!
+        project.configure(releaseNotes, closure)
+        return releaseNotes
+    }
+
+    fun releaseNotes(action: Action<ReleaseNotesExtension>): ReleaseNotesExtension {
+        releaseNotes = ReleaseNotesExtension()
+        action.execute(releaseNotes)
+        return releaseNotes
     }
 
     override fun toString(): String {
@@ -106,16 +117,16 @@ open class ReleasePhaseExtension {
 
 open class ReleaseNotesExtension {
 
-    var descriptions: List<ReleaseNote>? = null
+    var descriptions: List<ReleaseNote> = mutableListOf()
     var removeHtmlTags: Boolean? = null
 
     constructor()
 
-    constructor(descriptions: List<ReleaseNote>?) {
+    constructor(descriptions: List<ReleaseNote>) {
         this.descriptions = descriptions
     }
 
-    constructor(descriptions: List<ReleaseNote>?, removeHtmlTags: Boolean) {
+    constructor(descriptions: List<ReleaseNote>, removeHtmlTags: Boolean) {
         this.descriptions = descriptions
         this.removeHtmlTags = removeHtmlTags
     }

--- a/plugin/src/main/kotlin/ru/cian/huawei/publish/utils/ConfigProvider.kt
+++ b/plugin/src/main/kotlin/ru/cian/huawei/publish/utils/ConfigProvider.kt
@@ -143,9 +143,9 @@ internal class ConfigProvider(
 
     @Suppress("ThrowsCount")
     fun getReleasePhaseConfig(): ReleasePhaseConfig? {
-        val releasePhaseStartTime = cli.releasePhaseStartTime ?: extension.releasePhase?.startTime
-        val releasePhaseEndTime = cli.releasePhaseEndTime ?: extension.releasePhase?.endTime
-        val releasePhasePercent = cli.releasePhasePercent?.toDouble() ?: extension.releasePhase?.percent
+        val releasePhaseStartTime = cli.releasePhaseStartTime ?: extension.releasePhase.startTime
+        val releasePhaseEndTime = cli.releasePhaseEndTime ?: extension.releasePhase.endTime
+        val releasePhasePercent = cli.releasePhasePercent?.toDouble() ?: extension.releasePhase.percent
 
         val releasePhase =
             if (releasePhaseStartTime != null || releasePhaseEndTime != null || releasePhasePercent != null) {
@@ -200,15 +200,15 @@ internal class ConfigProvider(
         val releaseNotePairs = cli.releaseNotes?.split(";")?.map {
             val split = it.split(":")
             split[0] to split[1]
-        } ?: extension.releaseNotes?.descriptions?.map {
+        } ?: extension.releaseNotes.descriptions.map {
             it.lang to it.filePath
         }
 
-        if (releaseNotePairs == null) {
+        if (releaseNotePairs.isEmpty()) {
             return null
         }
 
-        val removeHtmlTags = cli.removeHtmlTags ?: extension.releaseNotes?.removeHtmlTags ?: false
+        val removeHtmlTags = cli.removeHtmlTags ?: extension.releaseNotes.removeHtmlTags ?: false
 
         val descriptions = releaseNotePairs.map {
 


### PR DESCRIPTION
* Improves nullability checks
* Compatible with the old way of assigning explicitly created instance of ReleasePhaseExtension/ReleaseNotesExtension
* Adds convenient and idiomatic way of configuring ReleasePhaseExtension/ReleaseNotesExtension in kts builds

Unfortunately, due to the weird way sample projects are wired into main project I can't adjust sample-kotlin project to reflect the change as it would break the build. Improving this wiring is quite a big change and requires a separate PR I guess.

Note that the test failure is not related to this change and fixed in a separate pr #67 