### PR TITLE
AGP 9 & Gradle 9/10 support

### DIFF
--- a/plugin/src/main/kotlin/ru/cian/huawei/publish/HuaweiPublishPlugin.kt
+++ b/plugin/src/main/kotlin/ru/cian/huawei/publish/HuaweiPublishPlugin.kt
@@ -1,24 +1,19 @@
 package ru.cian.huawei.publish
 
-import com.android.build.api.artifact.SingleArtifact
 import com.android.build.api.variant.ApplicationAndroidComponentsExtension
 import com.android.build.api.variant.ApplicationVariant
-import com.android.build.api.variant.VariantSelector
-import com.android.build.gradle.AppPlugin
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.tasks.TaskProvider
 import org.gradle.kotlin.dsl.create
 import org.gradle.kotlin.dsl.getByType
 import org.gradle.kotlin.dsl.register
-import org.gradle.kotlin.dsl.withType
-import java.io.File
 
 class HuaweiPublishPlugin : Plugin<Project> {
 
     override fun apply(project: Project) {
 
-        project.plugins.withType<AppPlugin> {
+        project.plugins.withId("com.android.application") {
             configureHuaweiPublish(project)
         }
     }
@@ -30,37 +25,19 @@ class HuaweiPublishPlugin : Plugin<Project> {
         )
 
         val androidComponents = project.extensions.getByType<ApplicationAndroidComponentsExtension>()
-        androidComponents.onVariants(androidComponents.selector().all() as VariantSelector) { variant ->
+        androidComponents.onVariants { variant ->
             createTask(project, variant)
         }
     }
 
-    @Suppress("DefaultLocale")
     private fun createTask(
         project: Project,
         variant: ApplicationVariant,
     ) {
-        val variantName = variant.name.capitalize()
+        val variantName = variant.name.replaceFirstChar { it.titlecase() }
         val publishTaskName = "${HuaweiPublishTask.TASK_NAME}$variantName"
         val publishTask = project.tasks.register<HuaweiPublishTask>(publishTaskName, variant)
         scheduleTasksOrder(publishTask, project, variantName)
-//
-//
-//        val variantName = variant.name
-//        val variantApplicationId = variant.applicationId.get()
-//        val variantApkBuildFilePath = getFinalApkArtifactCompat(variant).singleOrNull()?.absolutePath
-//        val variantAabBuildFilePath = getFinalBundleArtifactCompat(variant).singleOrNull()?.absolutePath
-// //        val variantApkBuildFilePath = project.rootProject.path + "/app/build/outputs/bundle/release/app-release.aab"
-// //        val variantAabBuildFilePath = project.rootProject.path + "/app/build/outputs/apk/release/app-release.apk"
-//        val publishTaskName = "${HuaweiPublishTask.TASK_NAME}${variantName.capitalize()}"
-//        val publishTask = project.tasks.register<HuaweiPublishTask>(
-//            publishTaskName,
-//            variantApplicationId,
-//            variantName,
-//            Optional.ofNullable(variantApkBuildFilePath),
-//            Optional.ofNullable(variantAabBuildFilePath),
-//        )
-// //        scheduleTasksOrder(publishTask, project, variantName)
     }
 
     private fun scheduleTasksOrder(
@@ -83,22 +60,5 @@ class HuaweiPublishPlugin : Plugin<Project> {
             val assembleTask = project.tasks.named(taskBeforeName).get()
             publishTask.get().mustRunAfter(assembleTask)
         }
-    }
-
-    // TODO(a.mirko): Remove after https://github.com/gradle/gradle/issues/16777
-    // TODO(a.mirko): Remove after https://github.com/gradle/gradle/issues/16775
-    @SuppressWarnings("UnusedPrivateMember")
-    private fun getFinalApkArtifactCompat(variant: ApplicationVariant): List<File> {
-        val apkDirectory = variant.artifacts.get(SingleArtifact.APK).get()
-        return variant.artifacts.getBuiltArtifactsLoader().load(apkDirectory)
-            ?.elements?.map { element -> File(element.outputFile) }
-            ?: apkDirectory.asFileTree.matching { include("*.apk") }.map { it.absolutePath }.map { File(it) }
-            ?: emptyList()
-    }
-
-    @SuppressWarnings("UnusedPrivateMember")
-    private fun getFinalBundleArtifactCompat(variant: ApplicationVariant): List<File> {
-        val aabFile = variant.artifacts.get(SingleArtifact.BUNDLE).get().asFile
-        return listOf(aabFile)
     }
 }

--- a/plugin/src/main/kotlin/ru/cian/huawei/publish/HuaweiPublishTask.kt
+++ b/plugin/src/main/kotlin/ru/cian/huawei/publish/HuaweiPublishTask.kt
@@ -28,10 +28,6 @@ import ru.cian.huawei.publish.utils.FileWrapper
 open class HuaweiPublishTask
 @Inject constructor(
     private val variant: ApplicationVariant,
-//    private val variantApplicationId: String,
-//    private val variantName: String,
-//    private val variantApkBuildFilePath: Optional<String?>,
-//    private val variantAabBuildFilePath: Optional<String?>,
 ) : DefaultTask() {
 
     private val logger by lazy { Logger(project) }
@@ -210,11 +206,6 @@ open class HuaweiPublishTask
         logger.i("cli=$cli")
 
         logger.v("1. Prepare input config")
-//        val buildFileProvider = BuildFileProviderNew(
-//            variantApkBuildFilePath = variantApkBuildFilePath.orElseGet(null),
-//            variantAabBuildFilePath = variantAabBuildFilePath.orElseGet(null),
-//            logger = logger,
-//        )
         val buildFileProvider = BuildFileProviderDeprecated(variant = variant, logger = logger)
 
         val config = ConfigProvider(


### PR DESCRIPTION
Fixes #66 

This makes the project forward-compatible with AGP 9 while maintaining compatibility with current AGP 8 dependency. Also makes it compatible with upcoming Gradle 9 & 10 versions.

Ideally it requires a test project to verify, but it requires a big build overhaul for this project. I'll consider doing that overhaul and then we could add an integration test with AGP 9 to that PR. However if you feel confident without a test feel free to merge.