### PR TITLE
Wire samples to the master version of the plugin

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,46 +1,25 @@
-// buildscript exist here for sample-groovy app;
-buildscript {
-    repositories {
-        google()
-    }
-
-    dependencies {
-        classpath("com.android.tools.build:gradle:" + libs.versions.androidGradlePlugin.get())
-    }
-}
-
 plugins {
-    alias(libs.plugins.kotlinJvm)
     alias(libs.plugins.benManesVersions)
 }
 
-allprojects {
-    repositories {
-        google()
-        mavenCentral()
+// Delegate lifecycle tasks to the plugin included build so that
+// ./gradlew build, ./gradlew check, etc. work from the root.
+val pluginBuild = gradle.includedBuild("plugin")
+
+listOf("build", "check", "assemble", "test", "detekt", "publishToMavenLocal", "publish").forEach { taskName ->
+    tasks.register(taskName) {
+        dependsOn(pluginBuild.task(":$taskName"))
     }
 }
 
-kotlin {
-    jvmToolchain {
-        languageVersion.set(JavaLanguageVersion.of(libs.versions.jvm.get()))
-    }
-}
+tasks.register("buildSamples") {
+    description = "Build all sample projects to verify plugin integration"
+    group = "verification"
 
-java {
-    toolchain {
-        languageVersion.set(JavaLanguageVersion.of(libs.versions.jvm.get()))
-    }
-}
-
-configurations.all {
-    resolutionStrategy {
-        eachDependency {
-            if (requested.group == "org.jetbrains.kotlin") {
-                useVersion(libs.versions.kotlin.get())
-            }
-        }
-    }
+    dependsOn(
+        gradle.includedBuild("sample-kotlin").task(":assembleDebug"),
+        gradle.includedBuild("sample-groovy").task(":assembleDemoDebug"),
+    )
 }
 
 tasks.withType<com.github.benmanes.gradle.versions.updates.DependencyUpdatesTask> {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -8,12 +8,11 @@ compileSdkVersion = "33"
 targetSdkVersion  = "33"
 minSdkVersion     = "21"
 
-jvm = "17"
+jvmTarget = "17"
 kotlin = "1.9.22"
 detekt = "1.23.4"
 junitJupiter = "5.9.3"
 androidGradlePlugin = "8.6.0"
-sampleHuaweiPlugin = "1.5.0"
 
 [libraries]
 appcompat = "androidx.appcompat:appcompat:1.6.1"
@@ -42,3 +41,5 @@ pluginPublish = { id = "com.gradle.plugin-publish", version = "0.15.0" }
 kotlinJvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
 benManesVersions = { id = "com.github.ben-manes.versions", version = "0.47.0" }
 detekt = { id = "io.gitlab.arturbosch.detekt", version.ref = "detekt" }
+androidApplication = { id = "com.android.application", version.ref = "androidGradlePlugin" }
+kotlinAndroid = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }

--- a/plugin/build.gradle.kts
+++ b/plugin/build.gradle.kts
@@ -11,6 +11,17 @@ plugins {
 apply(from = "$projectDir/config/check-jdk.gradle")
 apply(from = "$projectDir/config/gradle-portal.gradle")
 
+kotlin {
+    compilerOptions {
+        jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.fromTarget(libs.versions.jvmTarget.get()))
+    }
+}
+
+java {
+    sourceCompatibility = JavaVersion.toVersion(libs.versions.jvmTarget.get())
+    targetCompatibility = JavaVersion.toVersion(libs.versions.jvmTarget.get())
+}
+
 detekt {
 
     // The directories where detekt looks for source files.

--- a/plugin/config/check-jdk.gradle
+++ b/plugin/config/check-jdk.gradle
@@ -4,6 +4,6 @@ import org.gradle.api.JavaVersion
 def propertyJdk = project.properties["REQUIRED_JDK_VERSION"].toString()
 def requiredJdk = JavaLanguageVersion.of(propertyJdk)
 def currentJdk = JavaLanguageVersion.of(JavaVersion.current().majorVersion)
-if(currentJdk != requiredJdk){
-    throw new GradleException("This build must be run with ${requiredJdk}, current version is ${currentJdk}")
+if(currentJdk < requiredJdk){
+    throw new GradleException("This build requires JDK ${requiredJdk}+, current version is ${currentJdk}")
 }

--- a/plugin/settings.gradle.kts
+++ b/plugin/settings.gradle.kts
@@ -1,0 +1,18 @@
+pluginManagement {
+    repositories {
+        mavenLocal()
+        google()
+        gradlePluginPortal()
+        maven { url = uri("https://plugins.gradle.org/m2/") }
+    }
+}
+
+dependencyResolutionManagement {
+    versionCatalogs {
+        create("libs") {
+            from(files("../gradle/libs.versions.toml"))
+        }
+    }
+}
+
+rootProject.name = "plugin"

--- a/sample-groovy/build.gradle
+++ b/sample-groovy/build.gradle
@@ -1,17 +1,8 @@
-buildscript {
-    repositories {
-        mavenLocal()
-        gradlePluginPortal()
-    }
-
-    dependencies {
-        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:" + libs.versions.kotlin.get()
-        classpath "ru.cian.huawei-plugin:plugin:" + libs.versions.sampleHuaweiPlugin.get()
-    }
+plugins {
+    alias(libs.plugins.androidApplication)
+    alias(libs.plugins.kotlinAndroid)
+    id("ru.cian.huawei-publish-gradle-plugin")
 }
-
-apply plugin: "com.android.application"
-apply plugin: "ru.cian.huawei-publish-gradle-plugin"
 
 huaweiPublish {
     instances {
@@ -78,6 +69,15 @@ android {
             applicationIdSuffix ".debug"
             versionNameSuffix "-debug"
         }
+    }
+
+    compileOptions {
+        sourceCompatibility JavaVersion.toVersion(libs.versions.jvmTarget.get())
+        targetCompatibility JavaVersion.toVersion(libs.versions.jvmTarget.get())
+    }
+
+    kotlinOptions {
+        jvmTarget = libs.versions.jvmTarget.get()
     }
 
     flavorDimensions "version"

--- a/sample-groovy/settings.gradle
+++ b/sample-groovy/settings.gradle
@@ -1,0 +1,23 @@
+pluginManagement {
+    includeBuild('../plugin')
+    repositories {
+        google()
+        mavenCentral()
+        gradlePluginPortal()
+    }
+}
+
+dependencyResolutionManagement {
+    repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
+    repositories {
+        google()
+        mavenCentral()
+    }
+    versionCatalogs {
+        libs {
+            from(files('../gradle/libs.versions.toml'))
+        }
+    }
+}
+
+rootProject.name = 'sample-groovy'

--- a/sample-groovy/src/main/java/ru/cian/huawei/sample2/MainActivity.kt
+++ b/sample-groovy/src/main/java/ru/cian/huawei/sample2/MainActivity.kt
@@ -2,7 +2,7 @@ package ru.cian.huawei.sample2
 
 import android.os.Bundle
 import androidx.appcompat.app.AppCompatActivity
-import ru.cian.huawei.publish.sample2.R
+import ru.cian.huawei.sample.groovy.R
 
 class MainActivity : AppCompatActivity() {
 

--- a/sample-kotlin/build.gradle.kts
+++ b/sample-kotlin/build.gradle.kts
@@ -1,7 +1,7 @@
 plugins {
-    id("com.android.application")
-    id("kotlin-android")
-    id("ru.cian.huawei-publish")
+    alias(libs.plugins.androidApplication)
+    alias(libs.plugins.kotlinAndroid)
+    id("ru.cian.huawei-publish-gradle-plugin")
 }
 
 huaweiPublish {
@@ -67,8 +67,12 @@ android {
     }
 
     compileOptions {
-        sourceCompatibility = JavaVersion.toVersion(libs.versions.jvm.get())
-        targetCompatibility = JavaVersion.toVersion(libs.versions.jvm.get())
+        sourceCompatibility = JavaVersion.toVersion(libs.versions.jvmTarget.get())
+        targetCompatibility = JavaVersion.toVersion(libs.versions.jvmTarget.get())
+    }
+
+    kotlinOptions {
+        jvmTarget = libs.versions.jvmTarget.get()
     }
 }
 

--- a/sample-kotlin/settings.gradle.kts
+++ b/sample-kotlin/settings.gradle.kts
@@ -1,0 +1,23 @@
+pluginManagement {
+    includeBuild("../plugin")
+    repositories {
+        google()
+        mavenCentral()
+        gradlePluginPortal()
+    }
+}
+
+dependencyResolutionManagement {
+    repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
+    repositories {
+        google()
+        mavenCentral()
+    }
+    versionCatalogs {
+        create("libs") {
+            from(files("../gradle/libs.versions.toml"))
+        }
+    }
+}
+
+rootProject.name = "sample-kotlin"

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,27 +1,4 @@
-include("plugin")
-
-include(
-    ":sample-kotlin",
-    ":sample-groovy",
-//    ":sample-aar" // For uncomment should get error at sync project time as well;
-)
-
 pluginManagement {
-
-    val libsVersionFile = file("gradle/libs.versions.toml")
-    val properties = java.util.Properties().apply {
-        libsVersionFile.reader().use { load(it) }
-    }
-    val samplePublishVersion = properties.getProperty("sampleHuaweiPlugin").replace("\"", "")
-
-    resolutionStrategy {
-        eachPlugin {
-            if(requested.id.namespace == "ru.cian") {
-                useModule("ru.cian.huawei-plugin:plugin:${samplePublishVersion}")
-            }
-        }
-    }
-
     repositories {
         mavenLocal()
         google()
@@ -33,6 +10,10 @@ pluginManagement {
 plugins {
     id("com.gradle.enterprise") version("3.13.2")
 }
+
+includeBuild("plugin")
+includeBuild("sample-kotlin")
+includeBuild("sample-groovy")
 
 gradleEnterprise {
     buildScan {


### PR DESCRIPTION
Sorry, this patch started as a little rewiring of samples so that no `publishToMavenLocal` needed, but ended up in a full blown build maintenance that solves quite a few problems of build of this project. Sorry for the big patch in advance! Here is the summary of changes:

--- 

## Convert to fully composite build architecture

Restructured the project from a multi-project build with subprojects into a composite build where `plugin/`, `sample-kotlin/`, and `sample-groovy/` are all standalone builds composed via `includeBuild`.

### Root build

- Replaced `include("plugin")` with `includeBuild("plugin")`, `includeBuild("sample-kotlin")`, `includeBuild("sample-groovy")`
- Removed `resolutionStrategy` hack that parsed `libs.versions.toml` as a properties file to resolve the plugin version for samples
- Removed `buildscript` block (only existed for sample-groovy's AGP classpath) and `allprojects { repositories }` block
- Removed vestigial `configurations.all` Kotlin version pinning and `kotlinJvm` plugin (root has no source code)
- Added lifecycle delegating tasks (`build`, `check`, `test`, `detekt`, `publish`, `publishToMavenLocal`) that forward to the plugin included build
- Added `buildSamples` task that builds both samples in parallel within a single Gradle invocation via included build task references

### Plugin as standalone build

- Added `plugin/settings.gradle.kts` so plugin can be both an included build from root and built independently
- Imports the shared version catalog from `../gradle/libs.versions.toml`

### Sample projects as standalone builds

- Added `settings.gradle.kts` / `settings.gradle` per sample with:
  - `pluginManagement { includeBuild("../plugin") }` -- points directly to the plugin build for standalone use; when running as part of the composite, the root provides the plugin automatically via [Gradle's included-build plugin sharing](https://docs.gradle.org/current/userguide/composite_builds.html)
  - `dependencyResolutionManagement` with `FAIL_ON_PROJECT_REPOS` and shared version catalog
- Added `gradle.properties` per sample with `org.gradle.jvmargs=-Xmx2g` and AndroidX flags (standalone builds don't inherit root properties)
- **sample-kotlin** -- switched to `alias(libs.plugins.*)` for AGP/Kotlin and the full plugin ID `ru.cian.huawei-publish-gradle-plugin` (the short form `ru.cian.huawei-publish` only worked via the old resolution strategy). Added `compileOptions`/`kotlinOptions` targeting Java 17
- **sample-groovy** -- replaced `buildscript`/`apply plugin` pattern with modern `plugins {}` block. Added `kotlinAndroid` plugin (sample has Kotlin source), `compileOptions`, and `kotlinOptions`

### Bug fix

- `sample-groovy/.../MainActivity.kt` -- fixed wrong R import (`ru.cian.huawei.publish.sample2.R` -> `ru.cian.huawei.sample.groovy.R`, matching the declared namespace)

---

## Normalize JDK requirements to 17+

The project previously required exactly JDK 17. Changed to accept any JDK 17+ and target Java 17 bytecode.

| File | Change |
|------|--------|
| `gradle/libs.versions.toml` | Renamed `jvm` to `jvmTarget`, value `"17"`. Removed unused `sampleHuaweiPlugin`. Added `androidApplication` and `kotlinAndroid` plugin entries |
| `plugin/gradle.properties` | `REQUIRED_JDK_VERSION` `17` |
| `plugin/config/check-jdk.gradle` | Exact-match (`!=`) -> minimum-version (`<`) comparison |
| `plugin/build.gradle.kts` | Added explicit `kotlin { compilerOptions { jvmTarget = JVM_17 } }` and `java { sourceCompatibility/targetCompatibility = 17 }` -- bytecode is now deterministically Java 17 regardless of build JDK |
| `build.gradle.kts` | Removed `kotlin { jvmToolchain }` and `java { toolchain }` blocks (root has no source; toolchain would force JDK 17 download instead of allowing any 17+) |

---

## Changes in build commands caused by migration to includedBuild approach

```bash
# All the basic plugin lifecycle commands are delegated from root:
./gradlew build                # assemble + test + detekt
./gradlew assemble             # compile + jar
./gradlew test                 # run tests
./gradlew detekt               # run detekt
./gradlew publishToMavenLocal

# When you need flags like -x, use -p for direct invocation:
./gradlew -p plugin check -x test

# Build samples (parallel, single Gradle daemon):
./gradlew buildSamples

# Standalone sample builds:
./gradlew -p sample-kotlin assembleDebug
./gradlew -p sample-groovy assembleDemoDebug
```

No `publishToMavenLocal` step needed for samples. Plugin source changes are picked up automatically.
